### PR TITLE
Start of a NixOS module, flake tidying.

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,6 +36,10 @@ jobs:
           nix develop --command \
             cargo audit --deny warnings
 
+      - name: Flake Check
+        run: |
+          nix flake check
+
   build_and_test_nix:
     name: Test and build
     needs: check_nix

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ cargo build --release
 
 There are a few things left to do before considering ACME Crab "ready":
 
-* [ ] NixOS module - [#1]
+* [X] NixOS module - [#1]
 * [ ] Unit tests - [#2]
 * [ ] Integration tests - [#3]
 * [ ] Field testing. - [#4]

--- a/flake.nix
+++ b/flake.nix
@@ -82,5 +82,9 @@
             "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
           RUST_TOOLCHAIN_PATH = "${rust-toolchain}";
         };
-      });
+      }) // {
+        # Nix OS module.
+        nixosModules.default = { config, lib, pkgs, ... }:
+          import ./module/default.nix { inherit config lib pkgs self; };
+      };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
   outputs = { self, nixpkgs, utils, rust-overlay, crate2nix, ... }:
     let name = "acmecrab";
-    in utils.lib.eachDefaultSystem (system:
+    in utils.lib.eachSystem [ utils.lib.system.x86_64-linux ] (system:
       let
         pkgs = import nixpkgs {
           inherit system;
@@ -66,7 +66,7 @@
         packages.${name} = project.rootCrate.build;
 
         # `nix build`
-        defaultPackage = packages.${name};
+        packages.default = packages.${name};
 
         # `nix run`
         apps.${name} = utils.lib.mkApp {
@@ -76,7 +76,7 @@
         apps.default = apps.${name};
 
         # `nix develop`
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           inherit nativeBuildInputs;
           RUST_SRC_PATH =
             "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";

--- a/module/default.nix
+++ b/module/default.nix
@@ -1,0 +1,160 @@
+{ self, config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.acmecrab;
+  settingsFormat = pkgs.formats.json { };
+in {
+  # TODO(XXX): Additional validation checks/typing. E.g. of CIDR networks, FQDNs.
+  options.services.acmecrab = {
+    enable = mkEnableOption "Enable the acmecrab service";
+
+    domain = mkOption {
+      type = types.str;
+      example = "pki.example.com";
+      description = ''
+        Fully qualified domain name for the ACME Crab server.
+        All TXT records must be subdomains of this FQDN.
+      '';
+    };
+
+    ns_domain = mkOption {
+      type = types.str;
+      example = "ns1.pki.example.com";
+      description = ''
+        Fully qualified domain name for the nameserver to use in the SOA 
+        record for options.services.acmecrab.domain.
+      '';
+    };
+
+    ns_admin = mkOption {
+      type = types.str;
+      example = "dns-admin@example.com";
+      description = ''
+        Email address of the options.services.acmecrab.ns_domain
+        administrator. Translated to record format (e.g.
+        "foo@example.com" -> "foo.example.com") automatically.
+      '';
+    };
+
+    # TODO(XXX): Make state optional.
+    txt_store_state_path = mkOption {
+      type = types.str;
+      default = "/var/lib/acmecrab/txt_records.json";
+      description = ''
+        Path to a JSON data file for persisting TXT records across 
+        shutdown. Created at startup if it does not exist.
+      '';
+    };
+
+    api_bind_addr = mkOption {
+      type = types.str;
+      example = "10.233.1.2:8080";
+      description = ''
+        Bind address for HTTP API. Must be a loopback address or
+        private network.
+      '';
+    };
+
+    api_timeout = mkOption {
+      type = types.numbers.positive;
+      default = 120;
+      description = ''
+        Maximum duration for an API request before timing out, expressed 
+        in seconds
+      '';
+    };
+
+    dns_udp_bind_addr = mkOption {
+      type = types.str;
+      default = "0.0.0.0:53";
+      example = "10.233.1.2:53";
+      description = ''
+        Bind address for UDP DNS server.
+      '';
+    };
+
+    dns_tcp_bind_addr = mkOption {
+      type = types.str;
+      default = "0.0.0.0:53";
+      example = "10.233.1.2:53";
+      description = ''
+        Bind address for TCP DNS server.
+      '';
+    };
+
+    dns_tcp_timeout = mkOption {
+      type = types.numbers.positive;
+      default = 60;
+      description = ''
+        Maximum duration for a TCP DNS request before timing out, 
+        expressed in seconds.
+      '';
+    };
+
+    acl = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf (types.listOf types.str);
+      };
+      default = { };
+      example = { "127.0.0.0/24" = [ "subdomain_a" "subdomain_b" ]; };
+      description = ''
+        A map of CIDR networks and subdomains IPs within that network 
+        can updated TXT records for.'';
+    };
+
+    addrs = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf (types.listOf types.str);
+      };
+      default = { };
+      example = {
+        "pki.example.com" = [ "10.233.1.2" ];
+        "ns1.pki.example.com" = [ "10.233.1.2" ];
+      };
+      description = ''
+        A map of fully qualified domains and IP addresses that should
+        be used for A/AAAA queries for each domain.
+      '';
+    };
+
+    ns_records = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf (types.listOf types.str);
+      };
+      default = { };
+      example = { "pki.example.com" = [ "ns1.pki.example.com" ]; };
+      description = ''
+        A map of fully qualified domains to domain values that should be 
+        returned for NS lookups. 
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.acmecrab = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = let
+        pkg = self.packages.${pkgs.system}.acmecrab;
+        # TODO(XXX): this is a decent start on hardening options but we can do better.
+      in {
+        Restart = "on-failure";
+        ExecStart = "${pkg}/bin/acmecrab /etc/acmecrab.json";
+        Environment = "RUST_LOG=acmecrab=debug";
+        DynamicUser = "yes";
+        RuntimeDirectory = "acmecrab";
+        RuntimeDirectoryMode = "0755";
+        StateDirectory = "acmecrab";
+        StateDirectoryMode = "0700";
+        CacheDirectory = "acmecrab";
+        CacheDirectoryMode = "0750";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
+        ProtectHome = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6";
+      };
+    };
+
+    environment.etc."acmecrab.json".source =
+      settingsFormat.generate "acmecrab-config.json" cfg;
+  };
+}


### PR DESCRIPTION
### nix: x86_64 only for now, fix flake check warns. - 63814dd624996d410c482f4842450868559fd5a2

I suspect we can build fine on many additional system types but I'm only committed to testing x86_64-linux for the time being. This commit reflects that change in the flake. It also replaces some deprecated elements with their modern equivalent.

### ci: add flake check to workflows - bcba5ca2b25bd8f618ad1d16d93a667b31a2aefd

Makes sure we don't regress any clean up landed in the prev. commit.

### nix: add NixOS module. - ea00a7076e228ff59e10f1a433bcdacb3e78c1cb

This commit adds the start of a Flake exported NixOS module for ACME  Crab. This module allows using Nix to configure ACME Crab, producing a JSON config file and hardened systemd unit for the service.

This is an OK starting point, but there's work remaining to tighten up the validation (many elements are stringly-types) and the systemd unit hardening could be taken further.

Resolves #1.


