### PR TITLE
fix: allow capitalized JSON fields.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,7 @@
         # Example container.
         # `sudo nixos-container create acmecrab --flake .#container`
         # `sudo nixos-container start acmecrab`
+        # `dig @10.233.1.2 pki.example.com A`
         nixosConfigurations.container = let
           # NOTE(XXX): These values must match the output from `nixos-container create`.
           host_ip = "10.233.1.1";

--- a/src/api/model.rs
+++ b/src/api/model.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Debug, Clone, Default, Ord, PartialOrd, Eq, PartialEq)]
 pub(super) struct UpdateRecordRequest {
+    #[serde(alias = "SubDomain")]
     pub subdomain: String,
+    #[serde(alias = "Txt")]
     pub txt: String,
 }
 


### PR DESCRIPTION
The Lego acme-dns plugin POSTs JSON to the update TXT API that uses keys ["SubDomain" and "Txt"](https://github.com/cpu/goacmedns/blob/745426768bae5f19dd10e50fa340bba52e2da6ae/client.go#L177-L184). Prior to this commit acmecrab would reject those update requests as malformed. This commit updates the model to provide serde aliases matching these keys.